### PR TITLE
Infra: pre-requisite for using nessie gradle build plugin

### DIFF
--- a/codestyle/org.eclipse.wst.xml.core.prefs
+++ b/codestyle/org.eclipse.wst.xml.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+formatCommentJoinLines=false
+formatCommentText=false
+indentationChar=space
+indentationSize=2
+lineWidth=100
+spaceBeforeEmptyCloseTag=false


### PR DESCRIPTION
I am planning to use https://github.com/projectnessie/gradle-build-plugins in the project similar to cel-java and nessie.

Spotless needs codestyle/org.eclipse.wst.xml.core.prefs

https://github.com/projectnessie/gradle-build-plugins/blob/main/spotless/src/main/kotlin/org/projectnessie/buildtools/spotless/SpotlessHelperPlugin.kt#L42