### PR TITLE
upgrade to setup-gradle@v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         java-version: [11, 17, 18]
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
 
@@ -25,7 +25,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
 
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: --rerun-tasks assemble ${{ env.ADDITIONAL_GRADLE_OPTS }} check publishToMavenLocal --scan
 

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -52,13 +52,13 @@ jobs:
           java-version: 11
 
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_FROM }}
           fetch-depth: '0'
 
       - name: Bump to release version
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           cache-disabled: true
           arguments: :bumpVersion --bumpType ${{ env.BUMP_TYPE }} --bumpToRelease
@@ -124,7 +124,7 @@ jobs:
 
       # Bump to the next patch version as a SNAPSHOT
       - name: Bump to next patch version
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: :bumpVersion --bumpType patch
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -62,12 +62,12 @@ jobs:
           java-version: 11
 
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v4
         if: ${{ github.event_name == 'push' }}
         with:
           fetch-depth: '0'
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v4
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           fetch-depth: '0'


### PR DESCRIPTION
replaces https://github.com/projectnessie/iceberg-catalog-migrator/pull/127

note that the action has been renamed:
https://github.com/gradle/gradle-build-action

also simplify `actions/checkout` usage